### PR TITLE
fix: harden kali-server streaming fallback and execution lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,10 @@ export KALI_MCP_API_TOKEN="your-secret-token"
 ./kali-server                           # binds to 127.0.0.1:5000
 ./kali-server --ip 0.0.0.0 --port 5000  # expose on all interfaces
 ./kali-server --debug                   # verbose logging
+./kali-server --max-concurrent 30       # allow up to 30 concurrent execution requests
 ```
+
+`kali-server` limits concurrent execution requests to protect server resources. When the limit is exceeded, the server returns `503 Service Unavailable`.
 
 > **Tip:** Use an SSH tunnel instead of exposing `kali-server` directly on the network — it's simpler and more secure:
 > ```bash
@@ -240,6 +243,7 @@ Notes:
 | `--ip` | `127.0.0.1` | Bind address |
 | `--port` | `5000` | Listen port |
 | `--debug` | `false` | Verbose request logging |
+| `--max-concurrent` | `10` | Maximum number of concurrent execution requests before the server returns `503 Service Unavailable` |
 
 ### Environment variables
 
@@ -248,6 +252,8 @@ Notes:
 | `KALI_MCP_API_TOKEN` | both | **Required.** Bearer token for API authentication |
 | `KALI_MCP_DIR_WORDLIST` | kali-server | Override default dir wordlist (default: `/usr/share/wordlists/dirb/common.txt`) |
 | `KALI_MCP_JOHN_WORDLIST` | kali-server | Override default John wordlist (default: `/usr/share/wordlists/rockyou.txt`) |
+
+> `ReadTimeout` is enforced for incoming request bodies, while streaming responses remain unrestricted by `WriteTimeout`.
 
 ---
 

--- a/cmd/kali-server/handlers.go
+++ b/cmd/kali-server/handlers.go
@@ -41,7 +41,8 @@ func runToolStream[T dto.TimeoutRequest](c fiber.Ctx, validate func(T) error, ar
 	execCtx, cancel := context.WithCancel(c.Context())
 	timeout := commandTimeout(req.GetRequestTimeout())
 	lines, done := executor.StreamExec(execCtx, timeout, args[0], args[1:]...)
-	return sendToolStreamWithCancel(c, lines, done, cancel)
+	release := retainExecutionLease(c)
+	return sendToolStreamWithCancel(c, lines, done, cancel, release)
 }
 
 func handleCommand(c fiber.Ctx) error {
@@ -72,7 +73,8 @@ func handleCommandStream(c fiber.Ctx) error {
 	timeout := commandTimeout(req.Timeout)
 	execCtx, cancel := context.WithCancel(c.Context())
 	lines, done := executor.StreamShell(execCtx, timeout, req.Command)
-	return sendToolStreamWithCancel(c, lines, done, cancel)
+	release := retainExecutionLease(c)
+	return sendToolStreamWithCancel(c, lines, done, cancel, release)
 }
 
 func handleNmapStream(c fiber.Ctx) error {

--- a/cmd/kali-server/helpers.go
+++ b/cmd/kali-server/helpers.go
@@ -56,6 +56,10 @@ func internalServerError(c fiber.Ctx, msg string) error {
 	return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": msg})
 }
 
+func serviceUnavailable(c fiber.Ctx, msg string) error {
+	return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": msg})
+}
+
 func bindJSON(c fiber.Ctx, dst any) error {
 	return c.Bind().Body(dst)
 }

--- a/cmd/kali-server/limiter.go
+++ b/cmd/kali-server/limiter.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+const defaultMaxConcurrentExecutions = 10
+
+type executionLimiter struct {
+	sem chan struct{}
+}
+
+type executionLease struct {
+	release  func()
+	retained bool
+}
+
+const executionLeaseKey = "execution-lease"
+
+func newExecutionLimiter(maxConcurrent int) *executionLimiter {
+	if maxConcurrent <= 0 {
+		maxConcurrent = defaultMaxConcurrentExecutions
+	}
+	return &executionLimiter{sem: make(chan struct{}, maxConcurrent)}
+}
+
+func (l *executionLimiter) tryAcquire() bool {
+	if l == nil {
+		return true
+	}
+	select {
+	case l.sem <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (l *executionLimiter) release() {
+	if l == nil {
+		return
+	}
+	select {
+	case <-l.sem:
+	default:
+		panic(fmt.Sprintf("execution limiter release invariant violated: no slot to release (capacity=%d)", cap(l.sem)))
+	}
+}
+
+func withExecutionLimit(limiter *executionLimiter, next fiber.Handler) fiber.Handler {
+	if limiter == nil {
+		return next
+	}
+
+	return func(c fiber.Ctx) error {
+		if !limiter.tryAcquire() {
+			return serviceUnavailable(c, "server busy: too many concurrent executions")
+		}
+
+		lease := &executionLease{release: limiter.release}
+		c.Locals(executionLeaseKey, lease)
+
+		err := next(c)
+		if !lease.retained {
+			lease.release()
+		}
+		return err
+	}
+}
+
+func retainExecutionLease(c fiber.Ctx) func() {
+	lease, ok := c.Locals(executionLeaseKey).(*executionLease)
+	if !ok || lease == nil || lease.retained {
+		return nil
+	}
+
+	lease.retained = true
+	var once sync.Once
+	return func() {
+		once.Do(lease.release)
+	}
+}

--- a/cmd/kali-server/limiter.go
+++ b/cmd/kali-server/limiter.go
@@ -62,12 +62,13 @@ func withExecutionLimit(limiter *executionLimiter, next fiber.Handler) fiber.Han
 
 		lease := &executionLease{release: limiter.release}
 		c.Locals(executionLeaseKey, lease)
+		defer func() {
+			if !lease.retained {
+				lease.release()
+			}
+		}()
 
-		err := next(c)
-		if !lease.retained {
-			lease.release()
-		}
-		return err
+		return next(c)
 	}
 }
 

--- a/cmd/kali-server/main.go
+++ b/cmd/kali-server/main.go
@@ -30,20 +30,24 @@ type logPrinter func(format string, args ...any)
 
 func main() {
 	var (
-		ip    = flag.String("ip", "127.0.0.1", "bind address")
-		port  = flag.Int("port", 5000, "port")
-		debug = flag.Bool("debug", false, "verbose logging")
+		ip            = flag.String("ip", "127.0.0.1", "bind address")
+		port          = flag.Int("port", 5000, "port")
+		debug         = flag.Bool("debug", false, "verbose logging")
+		maxConcurrent = flag.Int("max-concurrent", defaultMaxConcurrentExecutions, "maximum number of concurrent execution requests")
 	)
 	flag.Parse()
 	apiToken := strings.TrimSpace(os.Getenv(dto.APITokenEnv))
 	if apiToken == "" {
 		log.Fatalf("%s must be set", dto.APITokenEnv)
 	}
+	if *maxConcurrent <= 0 {
+		log.Fatalf("--max-concurrent must be a positive integer")
+	}
 
 	log.SetFlags(log.LstdFlags | log.Lmsgprefix)
 	log.SetPrefix("[kali-server] ")
 
-	app := newApp(apiToken, *debug, log.Printf)
+	app := newApp(apiToken, *debug, *maxConcurrent, log.Printf)
 
 	addr := fmt.Sprintf("%s:%d", *ip, *port)
 	log.Printf("listening on %s", addr)
@@ -78,8 +82,8 @@ func main() {
 	}
 }
 
-func newApp(apiToken string, debug bool, print logPrinter) *fiber.App {
-	limiter := newExecutionLimiter(defaultMaxConcurrentExecutions)
+func newApp(apiToken string, debug bool, maxConcurrentExecutions int, print logPrinter) *fiber.App {
+	limiter := newExecutionLimiter(maxConcurrentExecutions)
 	app := fiber.New(fiber.Config{
 		ReadTimeout:  readTimeout,
 		WriteTimeout: 0,

--- a/cmd/kali-server/main.go
+++ b/cmd/kali-server/main.go
@@ -24,6 +24,8 @@ const shutdownTimeout = 10 * time.Second
 
 const streamHeartbeatInterval = 15 * time.Second
 
+const readTimeout = 10 * time.Second
+
 type logPrinter func(format string, args ...any)
 
 func main() {
@@ -77,8 +79,9 @@ func main() {
 }
 
 func newApp(apiToken string, debug bool, print logPrinter) *fiber.App {
+	limiter := newExecutionLimiter(defaultMaxConcurrentExecutions)
 	app := fiber.New(fiber.Config{
-		ReadTimeout:  0,
+		ReadTimeout:  readTimeout,
 		WriteTimeout: 0,
 		IdleTimeout:  5 * time.Minute,
 	})
@@ -86,28 +89,28 @@ func newApp(apiToken string, debug bool, print logPrinter) *fiber.App {
 		app.Use(debugRequestLogMiddleware(print))
 	}
 
-	registerRoutes(app, apiToken)
+	registerRoutes(app, apiToken, limiter)
 	return app
 }
 
-func registerRoutes(app *fiber.App, apiToken string) {
+func registerRoutes(app *fiber.App, apiToken string, limiter *executionLimiter) {
 	api := app.Group("/api", bearerAuthMiddleware(apiToken))
 
-	api.Post("/command", handleCommand)
-	api.Post("/command/stream", handleCommandStream)
+	api.Post("/command", withExecutionLimit(limiter, handleCommand))
+	api.Post("/command/stream", withExecutionLimit(limiter, handleCommandStream))
 
-	api.Post("/tools/gobuster", handleGobuster)
-	api.Post("/tools/nmap/stream", handleNmapStream)
-	api.Post("/tools/dirb/stream", handleDirbStream)
-	api.Post("/tools/nikto/stream", handleNiktoStream)
-	api.Post("/tools/wpscan/stream", handleWPScanStream)
-	api.Post("/tools/enum4linux/stream", handleEnum4linuxStream)
-	api.Post("/tools/sqlmap/stream", handleSQLMapStream)
-	api.Post("/tools/tshark/stream", handleTsharkStream)
-	api.Post("/tools/metasploit", handleMetasploit)
-	api.Post("/tools/hydra", handleHydra)
-	api.Post("/tools/hydra/stream", handleHydraStream)
-	api.Post("/tools/john", handleJohn)
+	api.Post("/tools/gobuster", withExecutionLimit(limiter, handleGobuster))
+	api.Post("/tools/nmap/stream", withExecutionLimit(limiter, handleNmapStream))
+	api.Post("/tools/dirb/stream", withExecutionLimit(limiter, handleDirbStream))
+	api.Post("/tools/nikto/stream", withExecutionLimit(limiter, handleNiktoStream))
+	api.Post("/tools/wpscan/stream", withExecutionLimit(limiter, handleWPScanStream))
+	api.Post("/tools/enum4linux/stream", withExecutionLimit(limiter, handleEnum4linuxStream))
+	api.Post("/tools/sqlmap/stream", withExecutionLimit(limiter, handleSQLMapStream))
+	api.Post("/tools/tshark/stream", withExecutionLimit(limiter, handleTsharkStream))
+	api.Post("/tools/metasploit", withExecutionLimit(limiter, handleMetasploit))
+	api.Post("/tools/hydra", withExecutionLimit(limiter, handleHydra))
+	api.Post("/tools/hydra/stream", withExecutionLimit(limiter, handleHydraStream))
+	api.Post("/tools/john", withExecutionLimit(limiter, handleJohn))
 
 	app.Get("/health", handleHealth)
 }

--- a/cmd/kali-server/main_test.go
+++ b/cmd/kali-server/main_test.go
@@ -999,7 +999,7 @@ func TestRegisterRoutesRejectsMissingBearerToken(t *testing.T) {
 	t.Parallel()
 
 	app := fiber.New()
-	registerRoutes(app, "secret-token")
+	registerRoutes(app, "secret-token", newExecutionLimiter(defaultMaxConcurrentExecutions))
 
 	req, err := http.NewRequest(http.MethodPost, "/api/tools/nmap/stream", strings.NewReader(`{"target":"127.0.0.1"}`))
 	if err != nil {
@@ -1022,7 +1022,7 @@ func TestRegisterRoutesAcceptsValidBearerToken(t *testing.T) {
 	t.Parallel()
 
 	app := fiber.New()
-	registerRoutes(app, "secret-token")
+	registerRoutes(app, "secret-token", newExecutionLimiter(defaultMaxConcurrentExecutions))
 
 	req, err := http.NewRequest(http.MethodPost, "/api/tools/nmap/stream", strings.NewReader(`{}`))
 	if err != nil {
@@ -1046,7 +1046,7 @@ func TestRegisterRoutesRejectsInvalidBearerToken(t *testing.T) {
 	t.Parallel()
 
 	app := fiber.New()
-	registerRoutes(app, "secret-token")
+	registerRoutes(app, "secret-token", newExecutionLimiter(defaultMaxConcurrentExecutions))
 
 	req, err := http.NewRequest(http.MethodPost, "/api/tools/nmap/stream", strings.NewReader(`{"target":"127.0.0.1"}`))
 	if err != nil {
@@ -1123,6 +1123,188 @@ func TestNewAppWithoutDebugDoesNotLogRequests(t *testing.T) {
 	if logged {
 		t.Fatal("expected debug logging to stay disabled")
 	}
+}
+
+func TestNewAppSetsReadTimeout(t *testing.T) {
+	t.Parallel()
+
+	app := newApp("secret-token", false, nil)
+	if got := app.Config().ReadTimeout; got != readTimeout {
+		t.Fatalf("expected read timeout %s, got %s", readTimeout, got)
+	}
+	if got := app.Config().WriteTimeout; got != 0 {
+		t.Fatalf("expected write timeout 0 for streaming, got %s", got)
+	}
+}
+
+func TestWithExecutionLimitRejectsWhenServerIsBusy(t *testing.T) {
+	t.Parallel()
+
+	limiter := newExecutionLimiter(1)
+	app := fiber.New()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+
+	app.Get("/limited", withExecutionLimit(limiter, func(c fiber.Ctx) error {
+		startedOnce.Do(func() { close(started) })
+		<-release
+		return c.SendStatus(fiber.StatusOK)
+	}))
+
+	firstRespCh := make(chan *http.Response, 1)
+	firstErrCh := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequest(http.MethodGet, "/limited", nil)
+		if err != nil {
+			firstErrCh <- err
+			return
+		}
+		resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+		if err != nil {
+			firstErrCh <- err
+			return
+		}
+		firstRespCh <- resp
+	}()
+
+	select {
+	case <-started:
+	case err := <-firstErrCh:
+		t.Fatalf("first request failed before limiter test: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("first request did not acquire the limiter in time")
+	}
+
+	secondReq, err := http.NewRequest(http.MethodGet, "/limited", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	secondResp, err := app.Test(secondReq, fiber.TestConfig{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("second request should fail fast with 503: %v", err)
+	}
+	defer secondResp.Body.Close()
+
+	secondBody, _ := io.ReadAll(secondResp.Body)
+	if secondResp.StatusCode != fiber.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d", fiber.StatusServiceUnavailable, secondResp.StatusCode)
+	}
+	if !strings.Contains(string(secondBody), "too many concurrent executions") {
+		t.Fatalf("expected busy message, got %s", string(secondBody))
+	}
+
+	close(release)
+
+	select {
+	case err := <-firstErrCh:
+		t.Fatalf("first request failed: %v", err)
+	case firstResp := <-firstRespCh:
+		defer firstResp.Body.Close()
+		if firstResp.StatusCode != fiber.StatusOK {
+			t.Fatalf("expected first request to complete with 200, got %d", firstResp.StatusCode)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first request did not finish after release")
+	}
+}
+
+func TestWithExecutionLimitRetainsLeaseForStreamingResponses(t *testing.T) {
+	t.Parallel()
+
+	limiter := newExecutionLimiter(1)
+	app := fiber.New()
+	started := make(chan struct{})
+	streamRelease := make(chan struct{})
+	var startedOnce sync.Once
+
+	app.Get("/limited-stream", withExecutionLimit(limiter, func(c fiber.Ctx) error {
+		startedOnce.Do(func() { close(started) })
+		lines := make(chan executor.Line)
+		done := make(chan *executor.Result, 1)
+		release := retainExecutionLease(c)
+		go func() {
+			<-streamRelease
+			close(lines)
+			done <- &executor.Result{ReturnCode: 0}
+			close(done)
+		}()
+		return sendToolStreamWithCancel(c, lines, done, nil, release)
+	}))
+
+	firstRespCh := make(chan *http.Response, 1)
+	firstErrCh := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequest(http.MethodGet, "/limited-stream", nil)
+		if err != nil {
+			firstErrCh <- err
+			return
+		}
+		resp, err := app.Test(req, fiber.TestConfig{Timeout: 2 * time.Second})
+		if err != nil {
+			firstErrCh <- err
+			return
+		}
+		firstRespCh <- resp
+	}()
+
+	select {
+	case <-started:
+	case err := <-firstErrCh:
+		t.Fatalf("first stream request failed before limiter test: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("first stream request did not start in time")
+	}
+
+	secondReq, err := http.NewRequest(http.MethodGet, "/limited-stream", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	secondResp, err := app.Test(secondReq, fiber.TestConfig{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("second stream request should fail fast with 503: %v", err)
+	}
+	defer secondResp.Body.Close()
+
+	secondBody, _ := io.ReadAll(secondResp.Body)
+	if secondResp.StatusCode != fiber.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d", fiber.StatusServiceUnavailable, secondResp.StatusCode)
+	}
+	if !strings.Contains(string(secondBody), "too many concurrent executions") {
+		t.Fatalf("expected busy message, got %s", string(secondBody))
+	}
+
+	close(streamRelease)
+
+	select {
+	case err := <-firstErrCh:
+		t.Fatalf("first stream request failed: %v", err)
+	case firstResp := <-firstRespCh:
+		defer firstResp.Body.Close()
+		if firstResp.StatusCode != fiber.StatusOK {
+			t.Fatalf("expected first stream request to complete with 200, got %d", firstResp.StatusCode)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("first stream request did not finish after release")
+	}
+}
+
+func TestExecutionLimiterReleasePanicsOnOverRelease(t *testing.T) {
+	t.Parallel()
+
+	limiter := newExecutionLimiter(1)
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected over-release to panic")
+		}
+		if !strings.Contains(fmt.Sprint(recovered), "execution limiter release invariant violated") {
+			t.Fatalf("expected invariant panic, got %v", recovered)
+		}
+	}()
+
+	limiter.release()
 }
 
 func TestRunToolRejectsEmptyCommandSlice(t *testing.T) {

--- a/cmd/kali-server/main_test.go
+++ b/cmd/kali-server/main_test.go
@@ -399,6 +399,32 @@ func TestRunSendToolStreamWritesFallbackWhenDoneClosesWithoutValue(t *testing.T)
 	}
 }
 
+func TestWriteStreamDoneFallbackEscapesJSONSafely(t *testing.T) {
+	t.Parallel()
+
+	buf := &strings.Builder{}
+	writer := bufio.NewWriter(buf)
+
+	writeStreamDoneFallback(writer, "bad\x00value")
+
+	events := mustParseSSEEvents(t, buf.String())
+	if len(events) != 1 {
+		t.Fatalf("expected 1 fallback SSE event, got %d (%s)", len(events), buf.String())
+	}
+	if !events[0].Done {
+		t.Fatalf("expected fallback done event, got %+v", events[0])
+	}
+	if events[0].ReturnCode == nil || *events[0].ReturnCode != -1 {
+		t.Fatalf("expected fallback return_code=-1, got %+v", events[0])
+	}
+	if events[0].Error != "bad\x00value" {
+		t.Fatalf("expected round-tripped fallback error, got %+v", events[0])
+	}
+	if !strings.Contains(buf.String(), `\u0000`) {
+		t.Fatalf("expected JSON-escaped control character in payload, got %q", buf.String())
+	}
+}
+
 func TestHandleNiktoStreamRejectsMissingTarget(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/kali-server/main_test.go
+++ b/cmd/kali-server/main_test.go
@@ -1070,7 +1070,7 @@ func TestNewAppWithDebugLogsRequests(t *testing.T) {
 	t.Parallel()
 
 	var lines []string
-	app := newApp("secret-token", true, func(format string, args ...any) {
+	app := newApp("secret-token", true, defaultMaxConcurrentExecutions, func(format string, args ...any) {
 		lines = append(lines, fmt.Sprintf(format, args...))
 	})
 
@@ -1101,7 +1101,7 @@ func TestNewAppWithoutDebugDoesNotLogRequests(t *testing.T) {
 	t.Parallel()
 
 	logged := false
-	app := newApp("secret-token", false, func(string, ...any) {
+	app := newApp("secret-token", false, defaultMaxConcurrentExecutions, func(string, ...any) {
 		logged = true
 	})
 
@@ -1128,12 +1128,30 @@ func TestNewAppWithoutDebugDoesNotLogRequests(t *testing.T) {
 func TestNewAppSetsReadTimeout(t *testing.T) {
 	t.Parallel()
 
-	app := newApp("secret-token", false, nil)
+	app := newApp("secret-token", false, defaultMaxConcurrentExecutions, nil)
 	if got := app.Config().ReadTimeout; got != readTimeout {
 		t.Fatalf("expected read timeout %s, got %s", readTimeout, got)
 	}
 	if got := app.Config().WriteTimeout; got != 0 {
 		t.Fatalf("expected write timeout 0 for streaming, got %s", got)
+	}
+}
+
+func TestNewExecutionLimiterUsesExplicitValue(t *testing.T) {
+	t.Parallel()
+
+	limiter := newExecutionLimiter(30)
+	if got := cap(limiter.sem); got != 30 {
+		t.Fatalf("expected limiter capacity 30, got %d", got)
+	}
+}
+
+func TestNewExecutionLimiterFallsBackToDefaultForInvalidValue(t *testing.T) {
+	t.Parallel()
+
+	limiter := newExecutionLimiter(0)
+	if got := cap(limiter.sem); got != defaultMaxConcurrentExecutions {
+		t.Fatalf("expected default limiter capacity %d, got %d", defaultMaxConcurrentExecutions, got)
 	}
 }
 

--- a/cmd/kali-server/stream.go
+++ b/cmd/kali-server/stream.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"strconv"
 	"strings"
 	"time"
 
@@ -176,6 +175,13 @@ func drainStreamLines(lines <-chan executor.Line) {
 }
 
 func writeStreamDoneFallback(w streamWriter, message string) {
-	_, _ = w.WriteString("data: {\"done\":true,\"return_code\":-1,\"error\":" + strconv.Quote(message) + "}\n\n")
+	returnCode := -1
+	payload, err := json.Marshal(dto.StreamEvent{Done: true, ReturnCode: &returnCode, Error: message})
+	if err != nil {
+		_, _ = w.WriteString("data: {\"done\":true,\"return_code\":-1,\"error\":\"internal error: failed to encode fallback event\"}\n\n")
+		_ = w.Flush()
+		return
+	}
+	_, _ = w.WriteString("data: " + string(payload) + "\n\n")
 	_ = w.Flush()
 }

--- a/cmd/kali-server/stream.go
+++ b/cmd/kali-server/stream.go
@@ -47,23 +47,29 @@ func terminalStreamError(result *executor.Result, streamedStderr string) string 
 	return strings.TrimLeft(terminalErr, "\n")
 }
 
-func sendToolStreamWithCancel(c fiber.Ctx, lines <-chan executor.Line, done <-chan *executor.Result, cancel context.CancelFunc) error {
+func sendToolStreamWithCancel(c fiber.Ctx, lines <-chan executor.Line, done <-chan *executor.Result, cancel context.CancelFunc, cleanups ...func()) error {
 	return sendToolStreamWithTicker(c, lines, done, cancel, func() streamTicker {
 		return newStreamTicker(streamHeartbeatInterval)
-	})
+	}, cleanups...)
 }
 
-func sendToolStreamWithTicker(c fiber.Ctx, lines <-chan executor.Line, done <-chan *executor.Result, cancel context.CancelFunc, tickerFactory func() streamTicker) error {
+func sendToolStreamWithTicker(c fiber.Ctx, lines <-chan executor.Line, done <-chan *executor.Result, cancel context.CancelFunc, tickerFactory func() streamTicker, cleanups ...func()) error {
 	c.Set("Content-Type", "text/event-stream")
 	c.Set("Cache-Control", "no-cache")
 	c.Set("X-Accel-Buffering", "no")
 
 	return c.SendStreamWriter(func(w *bufio.Writer) {
-		runSendToolStream(w, lines, done, cancel, tickerFactory)
+		runSendToolStream(w, lines, done, cancel, tickerFactory, cleanups...)
 	})
 }
 
-func runSendToolStream(w streamWriter, lines <-chan executor.Line, done <-chan *executor.Result, cancel context.CancelFunc, tickerFactory func() streamTicker) {
+func runSendToolStream(w streamWriter, lines <-chan executor.Line, done <-chan *executor.Result, cancel context.CancelFunc, tickerFactory func() streamTicker, cleanups ...func()) {
+	// Register in reverse so deferred execution preserves the caller's cleanup order.
+	for i := len(cleanups) - 1; i >= 0; i-- {
+		if cleanups[i] != nil {
+			defer cleanups[i]()
+		}
+	}
 	if cancel != nil {
 		defer cancel()
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -90,10 +90,13 @@ func execute(ctx context.Context, timeout time.Duration, cmdSpec commandSpec, em
 	}
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
+		_ = stdoutPipe.Close()
 		return &Result{Stderr: fmt.Sprintf("stderr pipe: %v", err), ReturnCode: -1}
 	}
 
 	if err := cmd.Start(); err != nil {
+		_ = stdoutPipe.Close()
+		_ = stderrPipe.Close()
 		return &Result{Stderr: fmt.Sprintf("start: %v", err), ReturnCode: -1}
 	}
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -2,11 +2,22 @@ package executor
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+func countOpenFDs(t *testing.T) int {
+	t.Helper()
+
+	entries, err := os.ReadDir("/dev/fd")
+	if err != nil {
+		t.Skipf("counting open file descriptors is unavailable: %v", err)
+	}
+	return len(entries)
+}
 
 func TestRunReportsScannerError(t *testing.T) {
 	t.Parallel()
@@ -160,5 +171,24 @@ func TestStreamExecDoneChannelIsBuffered(t *testing.T) {
 	_, done := StreamExec(context.Background(), 5*time.Second, "printf", "ok\n")
 	if cap(done) != 1 {
 		t.Fatalf("expected buffered done channel with capacity 1, got %d", cap(done))
+	}
+}
+
+func TestRunExecDoesNotLeakPipesWhenStartFails(t *testing.T) {
+	baseline := countOpenFDs(t)
+
+	for range 64 {
+		res := RunExec(context.Background(), time.Second, "/definitely/missing-binary")
+		if res == nil {
+			t.Fatal("expected result, got nil")
+		}
+		if res.ReturnCode != -1 {
+			t.Fatalf("expected start failure return code -1, got %d", res.ReturnCode)
+		}
+	}
+
+	after := countOpenFDs(t)
+	if delta := after - baseline; delta > 8 {
+		t.Fatalf("expected start failures not to leak file descriptors, baseline=%d after=%d delta=%d", baseline, after, delta)
 	}
 }


### PR DESCRIPTION
## Summary
- fix SSE fallback encoding to always emit valid JSON events
- close executor pipes on process startup failures to avoid descriptor leaks
- add execution limiting and a non-zero read timeout to harden long-running server requests
## Details
This PR improves the reliability of `kali-server` around streaming responses and command execution lifecycle handling.